### PR TITLE
Deliveries Changes

### DIFF
--- a/lib/raw_materials/interactors/rmt_bin_interactor.rb
+++ b/lib/raw_materials/interactors/rmt_bin_interactor.rb
@@ -477,7 +477,7 @@ module RawMaterialsApp
       error
     end
 
-    def create_rmt_bins(delivery_id, params) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def create_rmt_bins(delivery_id, params) # rubocop:disable Metrics/AbcSize
       res = validate_bin_asset_numbers_duplicate_scans(params)
       return validation_failed_response(OpenStruct.new(message: 'Validation Error', messages: res)) unless res.empty?
 
@@ -501,12 +501,9 @@ module RawMaterialsApp
         submitted_bins.each do |bin_asset_number|
           bin_params = { bin_asset_number: bin_asset_number }.merge(params)
           id = repo.create_rmt_bin(bin_params)
+          repo.allocate_delivery_bin_sample(bin_asset_number, id, delivery_id, delivery.cultivar_id, delivery.sample_bins)
           log_status(:rmt_bins, id, 'BIN RECEIVED')
         end
-
-        delivery_completed = delivery.quantity_bins_with_fruit == repo.select_values(:rmt_bins, :id, rmt_delivery_id: delivery_id).count
-        repo.allocate_delivery_bin_samples(delivery_id, delivery.cultivar_id, delivery.sample_bins) if delivery_completed && !delivery.sample_bins.nil_or_empty?
-
         log_status(:rmt_deliveries, delivery_id, 'DELIVERY RECEIVED')
         log_transaction
       end

--- a/lib/raw_materials/interactors/rmt_delivery_interactor.rb
+++ b/lib/raw_materials/interactors/rmt_delivery_interactor.rb
@@ -146,6 +146,7 @@ module RawMaterialsApp
       return nil unless repo.allocate_sample_rmt_bins_for_commodity_cultivar?(cultivar_id)
 
       sample_size = (AppConst::CR_RMT.sample_rmt_bin_percentage * quantity_bins_with_fruit).round
+      sample_size = 1 if sample_size.zero?
       generate_sample_bin_sequences(sample_size, quantity_bins_with_fruit)
     end
 

--- a/lib/raw_materials/ui_rules/rmt_delivery_rule.rb
+++ b/lib/raw_materials/ui_rules/rmt_delivery_rule.rb
@@ -108,7 +108,7 @@ module UiRules
         id: { renderer: :label, caption: 'Delivery Id' },
         sample_bins: { renderer: :label,
                        caption: 'Sample bin positions',
-                       with_value: @form_object.sample_bins.join(',') },
+                       with_value: @form_object.sample_bins.to_a.join(',') },
         farm_id: { renderer: :select,
                    options: MasterfilesApp::FarmRepo.new.for_select_farms,
                    disabled_options: MasterfilesApp::FarmRepo.new.for_select_inactive_farms,

--- a/lib/raw_materials/views/rmt_delivery/edit.rb
+++ b/lib/raw_materials/views/rmt_delivery/edit.rb
@@ -38,46 +38,38 @@ module RawMaterials
                                   behaviour: :popup,
                                   style: :button)
 
-              section.add_control(control_type: :link,
-                                  text: 'List Tripsheets',
+              list_tripsheets = { text: 'List Tripsheets',
                                   url: "/raw_materials/deliveries/rmt_deliveries/#{id}/list_tripsheet",
                                   behaviour: :popup,
-                                  visible: rules[:list_tripsheets],
-                                  style: :button)
+                                  visible: rules[:list_tripsheets] }
 
-              section.add_control(control_type: :link,
-                                  text: 'Create Tripsheet',
-                                  url: "/raw_materials/deliveries/rmt_deliveries/#{id}/create_tripsheet",
-                                  behaviour: :popup,
-                                  visible: rules[:create_tripsheet],
-                                  style: :button)
+              create_tripsheet = { text: 'Create Tripsheet',
+                                   url: "/raw_materials/deliveries/rmt_deliveries/#{id}/create_tripsheet",
+                                   behaviour: :popup,
+                                   visible: rules[:create_tripsheet] }
 
-              section.add_control(control_type: :link,
-                                  text: 'Start Bins Trip',
+              start_bins_trip = { text: 'Start Bins Trip',
                                   url: "/raw_materials/deliveries/rmt_deliveries/#{id}/start_bins_trip",
-                                  visible: rules[:start_bins_trip],
-                                  style: :button)
+                                  visible: rules[:start_bins_trip] }
 
-              cancel = { control_type: :link,
-                         text: 'Cancel Tripheet',
-                         url: "/raw_materials/deliveries/rmt_deliveries/#{id}/cancel_delivery_tripheet",
-                         visible: rules[:cancel_delivery_tripheet],
-                         style: :button }
-              cancel.store(:prompt, 'Vehicle is already loaded, do you want to cancel?') if rules[:vehicle_loaded]
-              section.add_control(cancel)
+              cancel_tripsheet = { text: 'Cancel Tripsheet',
+                                   url: "/raw_materials/deliveries/rmt_deliveries/#{id}/cancel_delivery_tripheet",
+                                   visible: rules[:cancel_delivery_tripheet] }
+              cancel_tripsheet.store(:prompt, 'Vehicle is already loaded, do you want to cancel?') if rules[:vehicle_loaded]
 
-              section.add_control(control_type: :link,
-                                  text: 'Print Tripsheet',
+              print_tripsheet = { text: 'Print Tripsheet',
                                   url: "/rmd/finished_goods/print_tripsheet/#{rules[:vehicle_job_id]}",
                                   visible: rules[:cancel_delivery_tripheet],
-                                  loading_window: true,
-                                  style: :button)
+                                  loading_window: true }
 
-              section.add_control(control_type: :link,
-                                  text: 'Refresh Tripsheet',
-                                  url: "/raw_materials/deliveries/rmt_deliveries/#{id}/refresh_delivery_tripheet",
-                                  visible: rules[:refresh_tripsheet],
-                                  style: :button)
+              refresh_tripsheet = { text: 'Refresh Tripsheet',
+                                    url: "/raw_materials/deliveries/rmt_deliveries/#{id}/refresh_delivery_tripheet",
+                                    visible: rules[:refresh_tripsheet] }
+
+              tripsheet_items = [create_tripsheet, start_bins_trip, list_tripsheets, cancel_tripsheet, print_tripsheet, refresh_tripsheet]
+              section.add_control(control_type: :dropdown_button,
+                                  text: 'Tripsheets',
+                                  items: tripsheet_items)
 
               section.add_notice rules[:mrl_result_notice], notice_type: :warning if AppConst::CR_RMT.enforce_mrl_check? && !rules[:mrl_result_notice].nil_or_empty?
               section.form do |form|

--- a/lib/raw_materials/views/rmt_delivery/show.rb
+++ b/lib/raw_materials/views/rmt_delivery/show.rb
@@ -30,46 +30,38 @@ module RawMaterials
                                   loading_window: true,
                                   style: :button)
 
-              section.add_control(control_type: :link,
-                                  text: 'List Tripsheets',
+              list_tripsheets = { text: 'List Tripsheets',
                                   url: "/raw_materials/deliveries/rmt_deliveries/#{id}/list_tripsheet",
                                   behaviour: :popup,
-                                  visible: rules[:list_tripsheets],
-                                  style: :button)
+                                  visible: rules[:list_tripsheets] }
 
-              section.add_control(control_type: :link,
-                                  text: 'Create Tripsheet',
-                                  url: "/raw_materials/deliveries/rmt_deliveries/#{id}/create_tripsheet",
-                                  behaviour: :popup,
-                                  visible: rules[:create_tripsheet],
-                                  style: :button)
+              create_tripsheet = { text: 'Create Tripsheet',
+                                   url: "/raw_materials/deliveries/rmt_deliveries/#{id}/create_tripsheet",
+                                   behaviour: :popup,
+                                   visible: rules[:create_tripsheet] }
 
-              section.add_control(control_type: :link,
-                                  text: 'Start Bins Trip',
+              start_bins_trip = { text: 'Start Bins Trip',
                                   url: "/raw_materials/deliveries/rmt_deliveries/#{id}/start_bins_trip",
-                                  visible: rules[:start_bins_trip],
-                                  style: :button)
+                                  visible: rules[:start_bins_trip] }
 
-              cancel = { control_type: :link,
-                         text: 'Cancel Tripheet',
-                         url: "/raw_materials/deliveries/rmt_deliveries/#{id}/cancel_delivery_tripheet",
-                         visible: rules[:cancel_delivery_tripheet],
-                         style: :button }
-              cancel.store(:prompt, 'Vehicle is already loaded, do you want to cancel?') if rules[:vehicle_loaded]
-              section.add_control(cancel)
+              cancel_tripsheet = { text: 'Cancel Tripsheet',
+                                   url: "/raw_materials/deliveries/rmt_deliveries/#{id}/cancel_delivery_tripheet",
+                                   visible: rules[:cancel_delivery_tripheet] }
+              cancel_tripsheet.store(:prompt, 'Vehicle is already loaded, do you want to cancel?') if rules[:vehicle_loaded]
 
-              section.add_control(control_type: :link,
-                                  text: 'Print Tripsheet',
+              print_tripsheet = { text: 'Print Tripsheet',
                                   url: "/rmd/finished_goods/print_tripsheet/#{rules[:vehicle_job_id]}",
                                   visible: rules[:cancel_delivery_tripheet],
-                                  loading_window: true,
-                                  style: :button)
+                                  loading_window: true }
 
-              section.add_control(control_type: :link,
-                                  text: 'Refresh Tripsheet',
-                                  url: "/raw_materials/deliveries/rmt_deliveries/#{id}/refresh_delivery_tripheet",
-                                  visible: rules[:refresh_tripsheet],
-                                  style: :button)
+              refresh_tripsheet = { text: 'Refresh Tripsheet',
+                                    url: "/raw_materials/deliveries/rmt_deliveries/#{id}/refresh_delivery_tripheet",
+                                    visible: rules[:refresh_tripsheet] }
+
+              tripsheet_items = [create_tripsheet, start_bins_trip, list_tripsheets, cancel_tripsheet, print_tripsheet, refresh_tripsheet]
+              section.add_control(control_type: :dropdown_button,
+                                  text: 'Tripsheets',
+                                  items: tripsheet_items)
 
               section.add_notice rules[:mrl_result_notice], notice_type: :warning if AppConst::CR_RMT.enforce_mrl_check? && !rules[:mrl_result_notice].nil_or_empty?
               section.form do |form|


### PR DESCRIPTION
Summary of this change:
Deliveries Changes
1. Sample bins allocated earlier in the process i.e. as a bin is created/added to the delivery, it is allocated if it's a sample.
2. edit delivery - tripsheet actions are grouped under one dropdown button i.e. create/delete/print tripsheet etc.
3. Generate at least one sample_bin position per delivery