### PR TITLE
pending mrl results 

### DIFF
--- a/lib/raw_materials/ui_rules/rmt_delivery_rule.rb
+++ b/lib/raw_materials/ui_rules/rmt_delivery_rule.rb
@@ -8,7 +8,7 @@ module UiRules
       apply_form_values
 
       @rules[:mrl_result_notice] = check_mrl_result_status_for(@form_object.id) unless @form_object.id.nil?
-      @rules[:create_tripsheet] = !@form_object.tripsheet_created && !@form_object.shipped && @rules[:mrl_result_notice].nil_or_empty?
+      @rules[:create_tripsheet] = !@form_object.tripsheet_created && !@form_object.shipped && @rules[:pending_mrl_result]
       @rules[:start_bins_trip] = @form_object.tripsheet_created && !@form_object.tripsheet_loaded
       @rules[:cancel_delivery_tripheet] = @form_object.tripsheet_created && !@form_object.tripsheet_offloaded
       @rules[:print_delivery_tripheet] = @rules[:cancel_delivery_tripheet]
@@ -248,6 +248,8 @@ module UiRules
       return nil unless AppConst::CR_RMT.enforce_mrl_check?
 
       res = QualityApp::FailedAndPendingMrlResults.call(delivery_id)
+      @rules[:failed_mrl_result] = res[:errors][:failed]
+      @rules[:pending_mrl_result] = res[:errors][:pending]
       res.success ? nil : res.message
     end
 

--- a/routes/rmd/raw_materials.rb
+++ b/routes/rmd/raw_materials.rb
@@ -1573,8 +1573,11 @@ class Nspack < Roda
         r.post do
           val_res = interactor.check_mrl_result_status_for(params[:bin][:bin_number])
           unless val_res.success
-            store_locally(:errors, val_res)
-            r.redirect("/rmd/rmt_deliveries/rmt_bins/add_bin_to_tripsheet/#{id}")
+            pending_mrl_result = val_res[:errors].nil_or_empty? ? false : val_res[:errors][:pending]
+            unless pending_mrl_result
+              store_locally(:errors, val_res)
+              r.redirect("/rmd/rmt_deliveries/rmt_bins/add_bin_to_tripsheet/#{id}")
+            end
           end
 
           res = interactor.add_bin_to_tripsheet(id, params[:bin][:bin_number])


### PR DESCRIPTION
Summary of this change:
pending mrl results should not stop a tripsheet from being created (or stop bins being added to a tripsheet)

### Fixed
- . pending mrl results should not stop a tripsheet from being created (or stop bins being added to a tripsheet)

How to test this code via the UI:
Raw Materials | Deliveries | Deliveries | edit
RMD | Raw Materials | Create Bin Tripsheet / Continue Bin Tripsheet 

