### PR TITLE
presort grower grading 

### DIFF
--- a/db/migrations/202201141357_add_rmt_bin_ids_to_presort_grower_grading_pools.rb
+++ b/db/migrations/202201141357_add_rmt_bin_ids_to_presort_grower_grading_pools.rb
@@ -1,0 +1,23 @@
+Sequel.migration do
+  up do
+    alter_table(:presort_grower_grading_pools) do
+      drop_column :track_slms_indicator_code
+      add_column :rmt_code_ids, 'integer[]'
+    end
+    run 'UPDATE presort_grower_grading_pools
+         SET rmt_code_ids = ts.rmt_bin_ids
+         FROM (SELECT rmt_bins.presort_tip_lot_number,
+                      array(SELECT DISTINCT a.rmt_code_id
+                            FROM rmt_bins a
+                            WHERE a.presort_tip_lot_number = rmt_bins.presort_tip_lot_number) AS rmt_bin_ids
+               FROM rmt_bins) ts
+         WHERE presort_grower_grading_pools.maf_lot_number = ts.presort_tip_lot_number;'
+  end
+
+  down do
+    alter_table(:presort_grower_grading_pools) do
+      add_column :track_slms_indicator_code, String
+      drop_column :rmt_code_ids
+    end
+  end
+end

--- a/grid_definitions/dataminer_queries/presort_grower_grading_pools.yml
+++ b/grid_definitions/dataminer_queries/presort_grower_grading_pools.yml
@@ -1,10 +1,11 @@
 ---
 :caption: Presort Grower Grading Pools
-:sql: "SELECT \"presort_grower_grading_pools\".\"id\",\r\n \"presort_grower_grading_pools\".\"maf_lot_number\",
-  \r\n\"presort_grower_grading_pools\".\"description\",\r\n \"presort_grower_grading_pools\".\"track_slms_indicator_code\",
-  \r\n\"presort_grower_grading_pools\".\"season_id\", \r\n\"presort_grower_grading_pools\".\"commodity_id\",
-  \r\n\"presort_grower_grading_pools\".\"farm_id\", \r\n\"commodities\".\"code\" AS
-  commodity_code, \r\n\"farms\".\"farm_code\", \r\n\"seasons\".\"season_code\", \r\n\"presort_grower_grading_pools\".\"rmt_bin_count\",\r\n\"presort_grower_grading_pools\".\"rmt_bin_weight\",
+:sql: "SELECT \"presort_grower_grading_pools\".\"id\",\r\n\"presort_grower_grading_pools\".\"maf_lot_number\",
+  \r\n\"presort_grower_grading_pools\".\"description\",\r\n\"presort_grower_grading_pools\".\"rmt_code_ids\",
+  \r\narray_remove(array_agg(DISTINCT rmt_codes.rmt_code::text), NULL::text) AS rmt_codes,\r\n\"presort_grower_grading_pools\".\"season_id\",
+  \r\n\"presort_grower_grading_pools\".\"commodity_id\", \r\n\"presort_grower_grading_pools\".\"farm_id\",
+  \r\n\"commodities\".\"code\" AS commodity_code, \r\n\"farms\".\"farm_code\", \r\n\"seasons\".\"season_code\",
+  \r\n\"presort_grower_grading_pools\".\"rmt_bin_count\",\r\n\"presort_grower_grading_pools\".\"rmt_bin_weight\",
   \r\n\"presort_grower_grading_pools\".\"pro_rata_factor\", \r\n\"presort_grower_grading_pools\".\"completed\",
   \r\n\"presort_grower_grading_pools\".\"active\", \r\n EXISTS(SELECT id FROM presort_grower_grading_bins
   WHERE presort_grower_grading_pool_id = presort_grower_grading_pools.id) AS has_grading_bins,\r\n\"presort_grower_grading_pools\".\"created_by\",
@@ -13,7 +14,10 @@
   \"presort_grower_grading_pools\".\"id\") AS status \r\nFROM \"presort_grower_grading_pools\"
   \r\nJOIN \"commodities\" ON \"commodities\".\"id\" = \"presort_grower_grading_pools\".\"commodity_id\"
   \r\nJOIN \"farms\" ON \"farms\".\"id\" = \"presort_grower_grading_pools\".\"farm_id\"
-  \r\nLEFT JOIN \"seasons\" ON \"seasons\".\"id\" = \"presort_grower_grading_pools\".\"season_id\""
+  \r\nLEFT JOIN \"seasons\" ON \"seasons\".\"id\" = \"presort_grower_grading_pools\".\"season_id\"\r\nLEFT
+  JOIN rmt_codes ON rmt_codes.id = ANY (presort_grower_grading_pools.rmt_code_ids)\r\nGROUP
+  BY \"presort_grower_grading_pools\".\"id\",\r\n\"commodities\".\"code\",\r\n\"farms\".\"farm_code\",
+  \r\n\"seasons\".\"season_code\""
 :limit: 
 :offset: 
 :external_settings: {}
@@ -66,17 +70,33 @@
     :group_avg: false
     :group_min: false
     :group_max: false
-  track_slms_indicator_code:
-    :name: track_slms_indicator_code
+  rmt_code_ids:
+    :name: rmt_code_ids
     :sequence_no: 4
-    :caption: Track slms indicator code
-    :namespaced_name: presort_grower_grading_pools.track_slms_indicator_code
+    :caption: Rmt code ids
+    :namespaced_name: presort_grower_grading_pools.rmt_code_ids
     :data_type: :string
-    :width: 140
+    :width: 
+    :format: 
+    :hide: true
+    :pinned: 
+    :groupable: false
+    :group_by_seq: 
+    :group_sum: false
+    :group_avg: false
+    :group_min: false
+    :group_max: false
+  rmt_codes:
+    :name: rmt_codes
+    :sequence_no: 5
+    :caption: Rmt codes
+    :namespaced_name: 
+    :data_type: :string
+    :width: 120
     :format: 
     :hide: false
     :pinned: 
-    :groupable: true
+    :groupable: false
     :group_by_seq: 
     :group_sum: false
     :group_avg: false
@@ -84,7 +104,7 @@
     :group_max: false
   season_id:
     :name: season_id
-    :sequence_no: 5
+    :sequence_no: 6
     :caption: Season
     :namespaced_name: presort_grower_grading_pools.season_id
     :data_type: :integer
@@ -100,7 +120,7 @@
     :group_max: false
   commodity_id:
     :name: commodity_id
-    :sequence_no: 6
+    :sequence_no: 7
     :caption: Commodity
     :namespaced_name: presort_grower_grading_pools.commodity_id
     :data_type: :integer
@@ -116,7 +136,7 @@
     :group_max: false
   farm_id:
     :name: farm_id
-    :sequence_no: 7
+    :sequence_no: 8
     :caption: Farm
     :namespaced_name: presort_grower_grading_pools.farm_id
     :data_type: :integer
@@ -132,7 +152,7 @@
     :group_max: false
   commodity_code:
     :name: commodity_code
-    :sequence_no: 8
+    :sequence_no: 9
     :caption: Commodity
     :namespaced_name: commodities.code
     :data_type: :string
@@ -148,7 +168,7 @@
     :group_max: false
   farm_code:
     :name: farm_code
-    :sequence_no: 9
+    :sequence_no: 10
     :caption: Farm
     :namespaced_name: farms.farm_code
     :data_type: :string
@@ -164,7 +184,7 @@
     :group_max: false
   season_code:
     :name: season_code
-    :sequence_no: 10
+    :sequence_no: 11
     :caption: Season
     :namespaced_name: seasons.season_code
     :data_type: :string
@@ -180,7 +200,7 @@
     :group_max: false
   rmt_bin_count:
     :name: rmt_bin_count
-    :sequence_no: 11
+    :sequence_no: 12
     :caption: Rmt bin count
     :namespaced_name: presort_grower_grading_pools.rmt_bin_count
     :data_type: :integer
@@ -196,7 +216,7 @@
     :group_max: false
   rmt_bin_weight:
     :name: rmt_bin_weight
-    :sequence_no: 12
+    :sequence_no: 13
     :caption: Rmt bin weight
     :namespaced_name: presort_grower_grading_pools.rmt_bin_weight
     :data_type: :number
@@ -212,7 +232,7 @@
     :group_max: false
   pro_rata_factor:
     :name: pro_rata_factor
-    :sequence_no: 13
+    :sequence_no: 14
     :caption: Pro rata factor
     :namespaced_name: presort_grower_grading_pools.pro_rata_factor
     :data_type: :number
@@ -228,7 +248,7 @@
     :group_max: false
   completed:
     :name: completed
-    :sequence_no: 14
+    :sequence_no: 15
     :caption: Completed
     :namespaced_name: presort_grower_grading_pools.completed
     :data_type: :boolean
@@ -244,7 +264,7 @@
     :group_max: false
   active:
     :name: active
-    :sequence_no: 15
+    :sequence_no: 16
     :caption: Active
     :namespaced_name: presort_grower_grading_pools.active
     :data_type: :boolean
@@ -260,7 +280,7 @@
     :group_max: false
   has_grading_bins:
     :name: has_grading_bins
-    :sequence_no: 16
+    :sequence_no: 17
     :caption: Has grading bins
     :namespaced_name: 
     :data_type: :boolean
@@ -276,7 +296,7 @@
     :group_max: false
   created_by:
     :name: created_by
-    :sequence_no: 17
+    :sequence_no: 18
     :caption: Created by
     :namespaced_name: presort_grower_grading_pools.created_by
     :data_type: :string
@@ -292,7 +312,7 @@
     :group_max: false
   updated_by:
     :name: updated_by
-    :sequence_no: 18
+    :sequence_no: 19
     :caption: Updated by
     :namespaced_name: presort_grower_grading_pools.updated_by
     :data_type: :string
@@ -308,7 +328,7 @@
     :group_max: false
   created_at:
     :name: created_at
-    :sequence_no: 19
+    :sequence_no: 20
     :caption: Created at
     :namespaced_name: presort_grower_grading_pools.created_at
     :data_type: :datetime
@@ -324,7 +344,7 @@
     :group_max: false
   updated_at:
     :name: updated_at
-    :sequence_no: 20
+    :sequence_no: 21
     :caption: Updated at
     :namespaced_name: presort_grower_grading_pools.updated_at
     :data_type: :datetime
@@ -340,7 +360,7 @@
     :group_max: false
   status:
     :name: status
-    :sequence_no: 21
+    :sequence_no: 22
     :caption: Status
     :namespaced_name: 
     :data_type: :string

--- a/lib/raw_materials/entities/presort_grower_grading_pool.rb
+++ b/lib/raw_materials/entities/presort_grower_grading_pool.rb
@@ -5,7 +5,7 @@ module RawMaterialsApp
     attribute :id, Types::Integer
     attribute :maf_lot_number, Types::String
     attribute :description, Types::String
-    attribute :track_slms_indicator_code, Types::String
+    attribute :rmt_code_ids, Types::Array
     attribute :season_id, Types::Integer
     attribute :commodity_id, Types::Integer
     attribute :farm_id, Types::Integer
@@ -24,7 +24,7 @@ module RawMaterialsApp
     attribute :id, Types::Integer
     attribute :maf_lot_number, Types::String
     attribute :description, Types::String
-    attribute :track_slms_indicator_code, Types::String
+    attribute :rmt_code_ids, Types::Array
     attribute :season_id, Types::Integer
     attribute :commodity_id, Types::Integer
     attribute :farm_id, Types::Integer
@@ -42,5 +42,6 @@ module RawMaterialsApp
     attribute :farm_code, Types::String
     attribute :total_graded_weight, Types::Decimal
     attribute :input_minus_output_weight, Types::Decimal
+    attribute :rmt_codes, Types::String
   end
 end

--- a/lib/raw_materials/services/create_presort_grower_grading_pool.rb
+++ b/lib/raw_materials/services/create_presort_grower_grading_pool.rb
@@ -32,9 +32,10 @@ module RawMaterialsApp
       failed_response(e.message)
     end
 
-    def create_presort_grading_pools
+    def create_presort_grading_pools # rubocop:disable Metrics/AbcSize
       repo.presort_grading_pool_details_for(maf_lot_number).each do |pool|
         pool[:created_by] = user_name
+        pool[:rmt_code_ids] = repo.select_values(:rmt_bins, :rmt_code_id, presort_tip_lot_number: pool[:maf_lot_number]).compact
         res = validate_presort_grading_pool_params(pool)
         return validation_failed_response(res) if res.failure?
 

--- a/lib/raw_materials/test/factories/presort_grower_grading_factory.rb
+++ b/lib/raw_materials/test/factories/presort_grower_grading_factory.rb
@@ -13,7 +13,7 @@ module RawMaterialsApp
       default = {
         maf_lot_number: Faker::Lorem.unique.word,
         description: Faker::Lorem.word,
-        track_slms_indicator_code: Faker::Lorem.word,
+        rmt_code_ids: nil,
         rmt_bin_count: Faker::Number.number(digits: 4),
         rmt_bin_weight: Faker::Number.decimal,
         pro_rata_factor: Faker::Number.decimal,

--- a/lib/raw_materials/test/interactors/test_presort_grower_grading_pool_interactor.rb
+++ b/lib/raw_materials/test/interactors/test_presort_grower_grading_pool_interactor.rb
@@ -88,7 +88,7 @@ module RawMaterialsApp
         id: 1,
         maf_lot_number: maf_lot_number,
         description: 'ABC',
-        track_slms_indicator_code: 'ABC',
+        rmt_code_ids: nil,
         season_id: season_id,
         commodity_id: commodity_id,
         farm_id: farm_id,

--- a/lib/raw_materials/test/task_permission_checks/test_presort_grower_grading_pool.rb
+++ b/lib/raw_materials/test/task_permission_checks/test_presort_grower_grading_pool.rb
@@ -12,7 +12,7 @@ module RawMaterialsApp
         id: 1,
         maf_lot_number: Faker::Lorem.unique.word,
         description: 'ABC',
-        track_slms_indicator_code: 'ABC',
+        rmt_code_ids: nil,
         season_id: 1,
         commodity_id: 1,
         farm_id: 1,

--- a/lib/raw_materials/ui_rules/presort_grower_grading_pool_rule.rb
+++ b/lib/raw_materials/ui_rules/presort_grower_grading_pool_rule.rb
@@ -24,8 +24,8 @@ module UiRules
       farm_id_label = @repo.get(:farms, :farm_code, @form_object.farm_id)
       fields[:maf_lot_number] = { renderer: :label }
       fields[:description] = { renderer: :label }
-      fields[:track_slms_indicator_code] = { renderer: :label,
-                                             caption: 'Track Indicator Code' }
+      fields[:rmt_codes] = { renderer: :label,
+                             caption: 'Rmt Codes' }
       fields[:season_id] = { renderer: :label,
                              with_value: season_id_label,
                              caption: 'Season' }
@@ -55,8 +55,8 @@ module UiRules
       {
         maf_lot_number: { required: true },
         description: {},
-        track_slms_indicator_code: { renderer: :label,
-                                     caption: 'Track Indicator Code' },
+        rmt_codes: { renderer: :label,
+                     caption: 'Rmt Codes' },
         season_id: { renderer: :label,
                      with_value: season_id_label,
                      caption: 'Season' },
@@ -79,13 +79,12 @@ module UiRules
     end
 
     def set_manage_pool_details(columns = nil, display_columns = 3)
-      compact_header(columns: columns || %i[maf_lot_number description track_slms_indicator_code season_code commodity_code
+      compact_header(columns: columns || %i[maf_lot_number description rmt_codes season_code commodity_code
                                             farm_code rmt_bin_count completed created_by updated_by created_at updated_at],
                      display_columns: display_columns,
                      header_captions: {
                        maf_lot_number: 'Maf Lot Number',
                        description: 'Description',
-                       track_slms_indicator_code: 'Track Indicator Code',
                        season_code: 'Season',
                        commodity_code: 'Commodity',
                        farm_code: 'Farm'

--- a/lib/raw_materials/validations/presort_grower_grading_pool_schema.rb
+++ b/lib/raw_materials/validations/presort_grower_grading_pool_schema.rb
@@ -14,7 +14,7 @@ module RawMaterialsApp
     optional(:id).filled(:integer)
     required(:maf_lot_number).filled(Types::StrippedString)
     optional(:description).maybe(Types::StrippedString)
-    required(:track_slms_indicator_code).maybe(Types::StrippedString)
+    optional(:rmt_code_ids).maybe(:array).maybe { each(:integer) }
     required(:season_id).maybe(:integer)
     required(:commodity_id).filled(:integer)
     required(:farm_id).filled(:integer)

--- a/lib/raw_materials/views/presort_grower_grading_pool/edit.rb
+++ b/lib/raw_materials/views/presort_grower_grading_pool/edit.rb
@@ -19,12 +19,12 @@ module RawMaterials
               form.method :update
               form.add_field :maf_lot_number
               form.add_field :description
-              form.add_field :track_slms_indicator_code
               form.add_field :season_id
               form.add_field :commodity_id
               form.add_field :farm_id
               form.add_field :rmt_bin_count
               form.add_field :rmt_bin_weight
+              form.add_field :rmt_codes
             end
           end
         end

--- a/lib/raw_materials/views/presort_grower_grading_pool/show.rb
+++ b/lib/raw_materials/views/presort_grower_grading_pool/show.rb
@@ -16,9 +16,9 @@ module RawMaterials
               form.row do |row|
                 row.column do |col|
                   col.add_field :maf_lot_number
-                  col.add_field :track_slms_indicator_code
                   col.add_field :commodity_id
                   col.add_field :rmt_bin_count
+                  col.add_field :rmt_codes
                   col.add_field :created_by
                   col.add_field :active
                 end

--- a/routes/raw_materials/presort_grower_grading.rb
+++ b/routes/raw_materials/presort_grower_grading.rb
@@ -178,7 +178,7 @@ class Nspack < Roda
             row_keys = %i[
               maf_lot_number
               description
-              track_slms_indicator_code
+              rmt_codes
               season_code
               commodity_code
               farm_code
@@ -236,7 +236,7 @@ class Nspack < Roda
             id
             maf_lot_number
             description
-            track_slms_indicator_code
+            rmt_codes
             season_code
             commodity_code
             farm_code


### PR DESCRIPTION
Summary of this change:
presort grower grading -  drop track_slms_indicator_code and add rmt_codes to presort_grower_grading_pools

Changed

    .  dropped track_slms_indicator_code and add rmt_codes to presort_grower_grading_pools

How to test this code via the UI:
Raw Materials | Presort Grower Grading | Presort Grading Pools | New Presort Grading Pool
