### PR TITLE
MRL Results - use puc instead of farm for sample rules

### DIFF
--- a/lib/quality/interactors/mrl_result_interactor.rb
+++ b/lib/quality/interactors/mrl_result_interactor.rb
@@ -7,7 +7,7 @@ module QualityApp
       return validation_failed_response(res) if res.failure?
 
       attrs = res.to_h
-      args = attrs[:pre_harvest_result] ? attrs.slice(:farm_id, :puc_id, :orchard_id, :cultivar_id, :season_id) : attrs.slice(:production_run_id)
+      args = attrs[:pre_harvest_result] ? attrs.slice(:puc_id, :cultivar_id, :season_id) : attrs.slice(:production_run_id)
       attrs[:existing_id] = repo.look_for_existing_mrl_result_id(args)
 
       success_response('Found existing mrl result', attrs)

--- a/lib/quality/services/failed_and_pending_mrl_results.rb
+++ b/lib/quality/services/failed_and_pending_mrl_results.rb
@@ -21,8 +21,8 @@ module QualityApp
     private
 
     def check_errors # rubocop:disable Metrics/AbcSize
-      farm_id, cultivar_id, season_id = repo.get_value(:rmt_deliveries, %i[farm_id cultivar_id season_id], id: rmt_delivery_id)
-      mrl_result_ids = repo.select_values(:mrl_results, :id, farm_id: farm_id, cultivar_id: cultivar_id, season_id: season_id)
+      puc_id, cultivar_id, season_id = repo.get_value(:rmt_deliveries, %i[puc_id cultivar_id season_id], id: rmt_delivery_id)
+      mrl_result_ids = repo.select_values(:mrl_results, :id, puc_id: puc_id, cultivar_id: cultivar_id, season_id: season_id)
       if mrl_result_ids.nil_or_empty?
         return OpenStruct.new(success: false,
                               instance: { rmt_delivery_id: rmt_delivery_id },

--- a/lib/raw_materials/interactors/rmt_delivery_interactor.rb
+++ b/lib/raw_materials/interactors/rmt_delivery_interactor.rb
@@ -571,7 +571,7 @@ module RawMaterialsApp
     end
 
     def check_existing_mrl_result_for(delivery_id)
-      arr = %i[farm_id puc_id orchard_id cultivar_id season_id]
+      arr = %i[puc_id cultivar_id season_id]
       args = mrl_result_repo.mrl_result_attrs_for(delivery_id, arr)
       existing_id = mrl_result_repo.look_for_existing_mrl_result_id(args)
       return failed_response("There is no existing mrl result for delivery id #{delivery_id}") if existing_id.nil?

--- a/lib/raw_materials/ui_rules/rmt_delivery_rule.rb
+++ b/lib/raw_materials/ui_rules/rmt_delivery_rule.rb
@@ -377,7 +377,7 @@ module UiRules
     end
 
     def mrl_result_id_for(delivery_id)
-      arr = %i[farm_id puc_id orchard_id cultivar_id season_id]
+      arr = %i[puc_id cultivar_id season_id]
       args = @mrl_result_repo.mrl_result_attrs_for(delivery_id, arr)
       @mrl_result_repo.look_for_existing_mrl_result_id(args)
     end


### PR DESCRIPTION
Summary of this change:
MRL Results - use puc instead of farm for sample rules

### Changed
- . MRL Results - use puc instead of farm for sample rules

How to test this code via the UI:
Raw Materials | Deliveries | Deliveries | View