### PR TITLE
Single pallet edit reworks run change - pm_bom_id validation rule

### DIFF
--- a/lib/production/interactors/reworks_run_interactor.rb
+++ b/lib/production/interactors/reworks_run_interactor.rb
@@ -1009,7 +1009,9 @@ module ProductionApp
       end
 
       params[:fruit_actual_counts_for_pack_id] = find_fruit_actual_counts_for_pack_id(params[:basic_pack_code_id].to_i, params[:std_fruit_size_count_id].to_i)
-      res = SequenceSetupDataContract.new.call(params)
+      has_individual_cartons = repo.get(:pallets, :has_individual_cartons, params[:pallet_id])
+      contract = SequenceSetupDataContract.new(has_individual_cartons: has_individual_cartons)
+      res = contract.call(params)
       return validation_failed_response(res) if res.failure?
 
       rejected_fields = %i[id product_setup_template_id pallet_label_name]

--- a/lib/production/ui_rules/reworks_run_sequence_rule.rb
+++ b/lib/production/ui_rules/reworks_run_sequence_rule.rb
@@ -124,6 +124,8 @@ module UiRules
       requires_standard_counts = commodity.requires_standard_counts
       default_mkting_org_id = @form_object[:marketing_org_party_role_id].nil_or_empty? ? MasterfilesApp::PartyRepo.new.find_party_role_from_party_name_for_role(AppConst::CR_PROD.default_marketing_org, AppConst::ROLE_MARKETER) : @form_object[:marketing_org_party_role_id]
       default_pm_type_id = @form_object[:pm_type_id].nil_or_empty? ? MasterfilesApp::BomRepo.new.find_pm_type(DB[:pm_types].where(pm_type_code: AppConst::DEFAULT_FG_PACKAGING_TYPE).select_map(:id))&.id : @form_object[:pm_type_id]
+      fields[:id] =  { renderer: :hidden }
+      fields[:pallet_id] =  { renderer: :hidden }
       fields[:pallet_number] =  { renderer: :label,
                                   with_value: @form_object[:pallet_number],
                                   caption: 'Pallet Number',

--- a/lib/production/validations/reworks_run_schema.rb
+++ b/lib/production/validations/reworks_run_schema.rb
@@ -258,9 +258,10 @@ module ProductionApp
   end
 
   class SequenceSetupDataContract < Dry::Validation::Contract
+    option :has_individual_cartons
+
     params do
       optional(:id).filled(:integer)
-      optional(:pallet_id).filled(:integer)
       required(:marketing_variety_id).filled(:integer)
       required(:customer_variety_id).maybe(:integer)
       required(:std_fruit_size_count_id).maybe(:integer)
@@ -310,7 +311,6 @@ module ProductionApp
     end
 
     rule(:pm_bom_id) do
-      has_individual_cartons = BaseRepo.new.get(:pallets, :has_individual_cartons, values[:pallet_id])
       key.failure 'must be filled' if values[:pm_bom_id].nil_or_empty? && has_individual_cartons && AppConst::CR_PROD.use_packing_specifications?
     end
   end

--- a/lib/production/validations/reworks_run_schema.rb
+++ b/lib/production/validations/reworks_run_schema.rb
@@ -260,6 +260,7 @@ module ProductionApp
   class SequenceSetupDataContract < Dry::Validation::Contract
     params do
       optional(:id).filled(:integer)
+      optional(:pallet_id).filled(:integer)
       required(:marketing_variety_id).filled(:integer)
       required(:customer_variety_id).maybe(:integer)
       required(:std_fruit_size_count_id).maybe(:integer)
@@ -306,6 +307,11 @@ module ProductionApp
 
     rule(:pm_mark_id) do
       key.failure 'must be filled' if values[:pm_mark_id].nil_or_empty? && AppConst::CR_PROD.use_packing_specifications?
+    end
+
+    rule(:pm_bom_id) do
+      has_individual_cartons = BaseRepo.new.get(:pallets, :has_individual_cartons, values[:pallet_id])
+      key.failure 'must be filled' if values[:pm_bom_id].nil_or_empty? && has_individual_cartons && AppConst::CR_PROD.use_packing_specifications?
     end
   end
 end

--- a/lib/production/views/reworks_run/edit_pallet_sequence.rb
+++ b/lib/production/views/reworks_run/edit_pallet_sequence.rb
@@ -26,6 +26,8 @@ module Production
                 row.column do |col|
                   col.add_field :pallet_number
                   col.add_field :pallet_sequence_number
+                  col.add_field :id
+                  col.add_field :pallet_id
                 end
               end
               form.row do |row|


### PR DESCRIPTION
Summary of this change:
Single pallet edit reworks run change - pm_bom_id validation rule

### Added
- . Single pallet edit reworks run change - pm_bom_id validation rule

How to test this code via the UI:

Production | Reworks | Single Pallet Edit