### PR TITLE
Bulk Rebin & Pallet updates in reworks

### DIFF
--- a/lib/production/interactors/reworks_run_interactor.rb
+++ b/lib/production/interactors/reworks_run_interactor.rb
@@ -637,13 +637,18 @@ module ProductionApp
 
     def rebin_production_run_attrs(production_run_id)
       instance = production_run(production_run_id)
-      { production_run_rebin_id: production_run_id,
-        farm_id: instance[:farm_id],
-        puc_id: instance[:puc_id],
-        orchard_id: instance[:orchard_id],
-        cultivar_group_id: instance[:cultivar_group_id],
-        cultivar_id: instance[:cultivar_id],
-        season_id: instance[:season_id] }
+      attrs =  { production_run_rebin_id: production_run_id,
+                 farm_id: instance[:farm_id],
+                 puc_id: instance[:puc_id],
+                 orchard_id: instance[:orchard_id],
+                 cultivar_group_id: instance[:cultivar_group_id],
+                 cultivar_id: instance[:cultivar_id],
+                 season_id: instance[:season_id],
+                 rmt_code_id: instance[:rmt_code_id],
+                 actual_cold_treatment_id: instance[:actual_cold_treatment_id],
+                 actual_ripeness_treatment_id: instance[:actual_ripeness_treatment_id] }
+      attrs[:colour_percentage_id] = instance[:colour_percentage_id] unless instance[:colour_percentage_id].nil?
+      attrs
     end
 
     def move_bin(production_run_id, children)
@@ -1179,9 +1184,14 @@ module ProductionApp
     end
 
     def production_run_attrs(production_run_id, instance)
-      { production_run_id: production_run_id,
-        packhouse_resource_id: instance[:packhouse_resource_id],
-        production_line_id: instance[:production_line_id] }.merge(farm_details_attrs(instance))
+      attrs = { production_run_id: production_run_id,
+                packhouse_resource_id: instance[:packhouse_resource_id],
+                production_line_id: instance[:production_line_id],
+                rmt_code_id: instance[:rmt_code_id],
+                actual_cold_treatment_id: instance[:actual_cold_treatment_id],
+                actual_ripeness_treatment_id: instance[:actual_ripeness_treatment_id] }.merge(farm_details_attrs(instance))
+      attrs[:colour_percentage_id] = instance[:colour_percentage_id] unless instance[:colour_percentage_id].nil?
+      attrs
     end
 
     def farm_details_attrs(instance)
@@ -1203,7 +1213,11 @@ module ProductionApp
     def production_run_description_changes(production_run_id, instance_data)
       { production_run_id: production_run_id,
         packhouse: instance_data[:packhouse],
-        line: instance_data[:line] }.merge(farm_detail_description_changes(instance_data))
+        line: instance_data[:line],
+        rmt_code: instance_data[:rmt_code],
+        actual_cold_treatment: instance_data[:actual_cold_treatment],
+        actual_ripeness_treatment: instance_data[:actual_ripeness_treatment],
+        colour_percentage: instance_data[:colour_percentage] }.merge(farm_detail_description_changes(instance_data))
     end
 
     def farm_detail_description_changes(instance_data)

--- a/lib/production/repositories/reworks_repo.rb
+++ b/lib/production/repositories/reworks_repo.rb
@@ -529,7 +529,9 @@ module ProductionApp
     def production_run_details(id)
       query = <<~SQL
         SELECT production_runs.id AS production_run_id, packhouse.plant_resource_code AS packhouse_code, line.plant_resource_code AS line_code,
-               farms.farm_code, pucs.puc_code, orchards.orchard_code, cultivar_groups.cultivar_group_code, cultivars.cultivar_name
+               farms.farm_code, pucs.puc_code, orchards.orchard_code, cultivar_groups.cultivar_group_code, cultivars.cultivar_name,
+               colour_percentages.colour_percentage, actual_cold_treatments.treatment_code AS actual_cold_treatment,
+               actual_ripeness_treatments.treatment_code AS actual_ripeness_treatment, rmt_codes.rmt_code
         FROM production_runs
         LEFT JOIN plant_resources packhouse ON packhouse.id = production_runs.packhouse_resource_id
         LEFT JOIN plant_resources line ON line.id = production_runs.production_line_id
@@ -538,6 +540,10 @@ module ProductionApp
         LEFT JOIN orchards ON orchards.id = production_runs.orchard_id
         LEFT JOIN cultivar_groups ON cultivar_groups.id = production_runs.cultivar_group_id
         LEFT JOIN cultivars ON cultivars.id = production_runs.cultivar_id
+        LEFT JOIN colour_percentages ON colour_percentages.id = production_runs.colour_percentage_id
+        LEFT JOIN treatments actual_cold_treatments ON actual_cold_treatments.id = production_runs.actual_cold_treatment_id
+        LEFT JOIN treatments actual_ripeness_treatments ON actual_ripeness_treatments.id = production_runs.actual_ripeness_treatment_id
+        LEFT JOIN rmt_codes ON rmt_codes.id = production_runs.rmt_code_id
         WHERE production_runs.id = #{id}
       SQL
       DB[query].all unless id.nil?


### PR DESCRIPTION
Summary of this change:
Bulk Rebin & Pallet updates in reworks - also copy over from run to rebins: rmt_code_id, colour_percentage (only if null on rebin), actual cold_treatment, actual ripeness treatment

### Changed
- . Bulk Rebin & Pallet updates in reworks - also copy over from run to rebins: rmt_code_id, colour_percentage (only if null on rebin), actual cold_treatment, actual ripeness treatment

How to test this code via the UI:
Production | Reworks | Bulk Pallet Run Update | New
Production | Reworks | Bulk Rebin Run Update | New

